### PR TITLE
psst: fix for brew warnings

### DIFF
--- a/Formula/psst.rb
+++ b/Formula/psst.rb
@@ -1,20 +1,20 @@
 # GENERATED FROM TEMPLATE. DO NOT EDIT!
 class  Psst < Formula
-  desc "psst"
+  desc "secrets distribution"
   homepage "https://github.com/dollarshaveclub/psst"
   url "git@github.com:dollarshaveclub/psst.git",
-      :using => :git,
-      :tag => "v0.2.0",
-      :revision => "67eca859aae1074f8e141e377a7132d6b5e4e2fa"
-  
-  head "git@github.com:dollarshaveclub/psst.git", :using => :git
+      using:    :git,
+      tag:      "v0.2.0",
+      revision: "67eca859aae1074f8e141e377a7132d6b5e4e2fa"
+
+  head "git@github.com:dollarshaveclub/psst.git", using: :git
 
   bottle do
     root_url "https://github.com/dollarshaveclub/psst/releases/download/v0.2.0"
     rebuild 1
-    sha256 "9ee65127bc27c596929474e1be95d4ec821e4771049d2aec74a1dcc7027942a5" => :el_capitan
-    sha256 "9ee65127bc27c596929474e1be95d4ec821e4771049d2aec74a1dcc7027942a5" => :high_sierra
-    sha256 "9ee65127bc27c596929474e1be95d4ec821e4771049d2aec74a1dcc7027942a5" => :sierra
+    sha256 el_capitan:  "9ee65127bc27c596929474e1be95d4ec821e4771049d2aec74a1dcc7027942a5"
+    sha256 high_sierra: "9ee65127bc27c596929474e1be95d4ec821e4771049d2aec74a1dcc7027942a5"
+    sha256 sierra:      "9ee65127bc27c596929474e1be95d4ec821e4771049d2aec74a1dcc7027942a5"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
Recently brew started displaying warnings on updates for the psst formula:

```
Warning: Calling `sha256 "digest" => :tag` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `sha256 tag: "digest"` instead.
Please report this issue to the dollarshaveclub/public tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/dollarshaveclub/homebrew-public/Formula/psst.rb:15
```

This should fix those.